### PR TITLE
Has the purs integration test have a JS dep calling another dep.

### DIFF
--- a/loom-build/src/Loom/Build/Core.hs
+++ b/loom-build/src/Loom/Build/Core.hs
@@ -178,7 +178,7 @@ buildLoomResolved logger (LoomBuildConfig sass) home dir (LoomResolved config ot
 
   js <- withLog logger "js" . firstT LoomJsError $ do
     let
-      jsDepDir = Js.JsUnpackDir (loomTmpFilePath dir </> "js" </> "node_modules")
+      jsDepDir = Js.JsUnpackDir (loomTmpFilePath dir </> "js")
       outputJs b = JsFile $ loomTmpFilePath dir </> b <.> "js"
     -- Fetch and unpack dependencies
     deps <- Js.fetchJs home (loomConfigResolvedJsDepsNpm config) (loomConfigResolvedJsDepsGithub config)

--- a/loom-cli/test/cli/build/run
+++ b/loom-cli/test/cli/build/run
@@ -5,6 +5,7 @@
 ROOT="$(pwd)"
 cd test/cli/build
 rm -rf dist
+rm -rf .loom
 export LOOM_SITE_PREFIX="http://test/prefix/"
 export LOOM_OUTPUT_HASKELL="dist/haskell"
 export LOOM_OUTPUT_SITE="dist/site"

--- a/loom-cli/test/cli/purs/components/c1/vanilla.js
+++ b/loom-cli/test/cli/purs/components/c1/vanilla.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = require('left')('foo', 5);
+module.exports = require('write-pad')('foo', 5);

--- a/loom-cli/test/cli/purs/loom.toml
+++ b/loom-cli/test/cli/purs/loom.toml
@@ -9,6 +9,7 @@
 [js.dependencies]
   npm = [
       ["left-pad", "1.1.3", "612f61c033f3a9e08e939f1caebeea41b6f3199a"]
+    , ["write-pad", "1.0.0", "8b2828b245fd3ab8a7c9a29698fbf7fa37bb3f8e"]
     ]
 
 [js.bundle.first]

--- a/loom-cli/test/cli/purs/run
+++ b/loom-cli/test/cli/purs/run
@@ -5,6 +5,7 @@
 ROOT="$(pwd)"
 cd test/cli/purs
 rm -rf dist
+rm -rf .loom
 export LOOM_SITE_PREFIX="http://test/prefix/"
 export LOOM_OUTPUT_HASKELL="dist/haskell"
 export LOOM_OUTPUT_SITE="dist/site"
@@ -24,5 +25,6 @@ contains() {
 file_exists "${LOOM_OUTPUT_HASKELL}/main.js"
 # contains "${LOOM_OUTPUT_HASKELL}/test_build.css" "\"/assets/other/components/c1/image.svg\""
 cd "$LOOM_OUTPUT_HASKELL"
+set -x
 js=$(node -e "eval(require('fs').readFileSync('main.js').toString());console.log(require('purs')['Foo'].foo5);")
-[ "$js" == "  foo" ]
+[ "$js" == "foo  " ]


### PR DESCRIPTION
**Edit:** The premise of this PR is incorrect. I saw a failure where `react` seemingly couldn't find `loose-envify` (baffling, because the React code doesn't even seem to look for it). Adding the `node_modules` worked, but after further investigation, I couldn't reproduce the original failure. Browserify, when called, is provides the `.loom/js` folder as a location to `require()` from, both within our code, and inside libraries themselves. So! I've reversed the actual change, and left the test.

The more-or-less original (wrong) description follows:

---

Yeah, sorry.

We have a structure that looks like this:

```
.loom/
  |-- main.js (and other bundles)
  '-- js/
        |-- react/
        |-- loose-envify/
        | ...
```

Currently, the JS deps can't find each other. Node looks up the tree for the nearest `node_modules` path (see https://nodejs.org/api/modules.html#modules_all_together); you can override this with `NODE_PATHS`, but I'd prefer to:

1. Nest one level deeper anyway, to put it in a separate namespace from the output bundles themselves. ~Doing a `require('./foo')` in Node can point to either `./foo.js` or `./foo/index.js`, thanks to the resolving rules.~ Edit: The bundles are actually at the top-level, in `.loom/`; this is wrong.
2. Use the blessed node_modules name and get on with it.

(This is needed before we can get the Bikeshed pursdeps branch building with Loom master.)

! @thumphries @charleso 

/jury approved @charleso @thumphries