### PR TITLE
Unpack JS deps to node_modules dir

### DIFF
--- a/loom-build/src/Loom/Build/Core.hs
+++ b/loom-build/src/Loom/Build/Core.hs
@@ -187,7 +187,7 @@ buildLoomResolved logger (LoomBuildConfig sass) mode home dir (LoomResolved conf
 
   js <- withLog logger "js" . firstT LoomJsError $ do
     let
-      jsDepDir = Js.JsUnpackDir (loomTmpFilePath dir </> "js")
+      jsDepDir = Js.JsUnpackDir (loomTmpFilePath dir </> "js" </> "node_modules")
       outputJs b = JsFile $ loomTmpFilePath dir </> b <.> "js"
     -- Fetch and unpack dependencies
     deps <- Js.fetchJs home (loomConfigResolvedJsDepsNpm config) (loomConfigResolvedJsDepsGithub config)


### PR DESCRIPTION
~~This is necessary to make Browserify apply global transformations to NPM dependencies. There are strings in Browserify to that effect, it looks for `node_modules` in the path to decide if a global transform should be run or not.~~

https://github.com/substack/node-browserify/blob/16351573dd752002d3c87fbdc2fd787b69194218/index.js#L542

~~I have no idea why exactly this was working locally and not on boris. Eerie...~~

As below, this is necessary because browserify will occasionally require and evaluate modules. Packages can chuck them into the "browserify" section of package.json and it will just run them. It uses the node resolution rules to find them, wherein it walks backwards looking for `node_modules`.

! @charleso @damncabbage @sphvn 
/jury approved @charleso @damncabbage