### PR TITLE
Resolve transitive external dependencies

### DIFF
--- a/loom-build/loom-build.cabal
+++ b/loom-build/loom-build.cabal
@@ -23,7 +23,7 @@ library
                     , ambiata-twine
                     , ambiata-x-eithert
                     , async                           == 2.1.*
-                    , containers                      >= 0.4        && < 0.6
+                    , containers                      >= 0.5.8        && < 0.6
                     , directory                       == 1.2.*
                     , exceptions                      == 0.8.*
                     , filepath                        >= 1.4        && < 1.6


### PR DESCRIPTION
As discussed, requiring global consistency for external dependencies is the safest option for now, although obviously it will become very painful in short order. We can't possibly permit the silent omission of transitive dependencies, as it will likely be a horrible runtime failure; likewise we can't allow the top-level project to always clobber versions for transitive deps.

This PR combines the dependencies of all loom projects, and ensures they are consistent before allowing them to be used.

An alternative to this might be to force the top-level user to bring transitive dependencies into their loom file, rather than automatically slurping in whatever the subproject suggests.

! @charleso @sphvn @damncabbage 
/jury approved @sphvn