### PR TITLE
Makes the site Loom image fit into the column it's been given.

### DIFF
--- a/loom-site/src/Loom/Site.hs
+++ b/loom-site/src/Loom/Site.hs
@@ -215,7 +215,9 @@ loomHomeHtml =
     H.div ! HA.class_ "loom-container-medium" $
       H.div ! HA.class_ "loom-vertical-grouping" $ do
         H.h1 ! HA.class_ "loom-h1" $ "Welcome to loom"
-        H.img ! HA.src "https://cloud.githubusercontent.com/assets/355756/23049526/c99ade24-f510-11e6-851c-3e7902ed310c.jpg"
+        H.img
+          ! HA.style "max-width: 100%;"
+          ! HA.src "https://cloud.githubusercontent.com/assets/355756/23049526/c99ade24-f510-11e6-851c-3e7902ed310c.jpg"
 
 loomHowHtml :: LoomSitePrefix -> HtmlFile
 loomHowHtml spx =


### PR DESCRIPTION
Because the massive overhanging horizontal-scroll-requiring image bugs the crap out of me. :E 

<img width="959" alt="screen shot 2017-04-27 at 9 47 02 am" src="https://cloud.githubusercontent.com/assets/133028/25461815/7f948b32-2b2e-11e7-9777-60319ec8fda2.png">

! @thumphries @russmaxdesign 
/jury approved @russmaxdesign @thumphries