### PR TITLE
Adds a <meta> charset to stop the browser (correctly) whinging.

### DIFF
--- a/loom-site/src/Loom/Site.hs
+++ b/loom-site/src/Loom/Site.hs
@@ -414,6 +414,7 @@ htmlRawTemplate spx csss title body = do
   H.docType
   H.html $ do
     H.head $ do
+      H.meta ! HA.charset "utf-8"
       H.title . H.text . renderSiteTitle $ title
 
       for_ csss $ \css ->


### PR DESCRIPTION
Said whinging:
> The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.

! @thumphries @sphvn

Edit: I'd have lumped it with the Loom image PR, but this really is a completely separate thing.
/jury approved @thumphries @sphvn