### PR TITLE
Switch on detectGlobals for the JS browserify build

### DIFF
--- a/loom-js/data/browserify.js
+++ b/loom-js/data/browserify.js
@@ -81,7 +81,7 @@ getStdinThen(function(stdin){
   var bundler =
     browserify({
       debug: !(isProduction), // Toggles sourcemaps
-      detectGlobals: false,
+      detectGlobals: true,
       paths: paths,
       entries: oMap(function(key, val) { return key; }, entries),
     })


### PR DESCRIPTION
… to allow us to use Node libraries that refer to `global`, etc.

This was switched off for the sake of speed, but it turns out switching it back on doesn't seem to slow things down (I see ~6.1 seconds still, across multiple runs).

The particular case for this is part of a compound change:
* Manor's Feed Config page needs to parse the query parameters.
* A near-future Bikeshed PR adds an X.Dom.searchAsArray to provide a key-value list (it's a plain string you have to parse otherwise).
* The best library that provides this (`url-search-params`, something that emulates the somewhat cross-browser [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API) refers to `global` as part of its environment detection (using the existing one if it's already present). The alternative libraries do worse, or are not usable by us.

so i'm changing loom to change bikeshed to change manor

! @sphvn @charleso @don41382 
/jury approved @charleso