### PR TITLE
Push datatype codegen to Projector

### DIFF
--- a/loom-projector/src/Loom/Projector.hs
+++ b/loom-projector/src/Loom/Projector.hs
@@ -112,7 +112,7 @@ projectorOutputModuleExprs (ProjectorOutput (BuildArtefacts _decls _nmap ms) _um
   fmap (fmap Projector.meExpr . Map.elems . Projector.moduleExprs) $ ms
 
 -- FIX Should be in machinator
-type MachinatorModules = Map.Map Projector.DataModuleName [MC.Definition]
+type MachinatorModules = Map.Map FilePath [MC.Definition]
 
 compileProjector ::
   MachinatorModules ->

--- a/loom-projector/src/Loom/Projector.hs
+++ b/loom-projector/src/Loom/Projector.hs
@@ -128,7 +128,7 @@ compileProjector
         input
   let
     udts' = with mo Projector.machinatorDecls
-    decls = fold (Map.elems udts')
+    decls = decls1 <> fold (Map.elems udts')
   BuildArtefacts decls2 nmap2 oh2 <- firstT ProjectorError . hoistEither $
     Projector.runBuildIncremental
       (Projector.Build (moduleNamer prefix root) mempty)
@@ -140,7 +140,7 @@ compileProjector
   hoistEither . first ProjectorError $
     Projector.warnModules decls oh2
   let
-    bas = BuildArtefacts (decls <> decls1 <> decls2) (nmap1 <> nmap2) oh2
+    bas = BuildArtefacts (decls <> decls2) (nmap1 <> nmap2) oh2
     uma = um <> makeUsefulMap bas
   pure $ ProjectorOutput bas uma
 

--- a/loom-projector/src/Loom/Projector.hs
+++ b/loom-projector/src/Loom/Projector.hs
@@ -30,7 +30,7 @@ import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Catch (handleIf)
 
 import           Data.Map (Map)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
@@ -130,10 +130,11 @@ compileProjector
   let
     decls =
       Projector.machinatorDecls . join . Map.elems $ udts
+    udts' = with udts Projector.machinatorDecls
   BuildArtefacts decls2 nmap2 oh2 <- firstT ProjectorError . hoistEither $
     Projector.runBuildIncremental
-      (Projector.Build (moduleNamer prefix root) (Map.keys udts))
-      (Projector.UserDataTypes decls)
+      (Projector.Build (moduleNamer prefix root) mempty)
+      (Projector.UserDataTypes (fmap (second Projector.unTypeDecls) (Map.toList udts')))
       (userConstants images js)
       oh1
       (Projector.RawTemplates templates)

--- a/loom-projector/src/Loom/Projector.hs
+++ b/loom-projector/src/Loom/Projector.hs
@@ -190,6 +190,7 @@ moduleNamer prefix root =
           else fp
   in Projector.ModuleNamer
        (Projector.pathToModuleName mnr . takeDirectory . makeRelative root)
+       (Projector.pathToDataModuleName mnr . takeDirectory . makeRelative root)
        (\fp -> Projector.Name . T.pack $
          T.unpack prefix </> (dropFileIfDefault . dropExtension . makeRelative root $ fp))
 

--- a/loom-site/src/Loom/Site.hs
+++ b/loom-site/src/Loom/Site.hs
@@ -163,7 +163,7 @@ resolveSiteComponent ::
   -> ProjectorOutput
   -> Component
   -> EitherT LoomSiteError IO SiteComponent
-resolveSiteComponent spfx apfx css images js mo po c =
+resolveSiteComponent spfx apfx css images js (MachinatorOutput mo) po c =
   let
     root =
       loomFilePath . componentPath $ c
@@ -180,13 +180,13 @@ resolveSiteComponent spfx apfx css images js mo po c =
         fc <- safeIO $ T.readFile f
         po' <- firstT LoomSiteProjectorError $
           P.compileProjector
-            (machinatorOutputToProjector mo)
+            mo
             po
             (P.ProjectorInput "ignore" root images js [f])
         for (join . Map.elems . Projector.projectorOutputModuleExprs $ po') $
           fmap ((T.pack . File.takeBaseName $ f), fc,) .
             fmap projectorHtmlToBlaze . hoistEither . first LoomSiteProjectorInterpretError .
-              Projector.generateProjectorHtml (machinatorOutputToProjector mo) spfx apfx css images js po
+              Projector.generateProjectorHtml mo spfx apfx css images js po
     findPrj =
       catMaybes $ fmap (flip Map.lookup (Projector.projectorTermMap po)) (fmap componentFilePath (componentProjectorFiles c))
 

--- a/loom-site/src/Loom/Site.hs
+++ b/loom-site/src/Loom/Site.hs
@@ -180,9 +180,8 @@ resolveSiteComponent spfx apfx css images js (MachinatorOutput mo) po c =
         fc <- safeIO $ T.readFile f
         po' <- firstT LoomSiteProjectorError $
           P.compileProjector
-            mo
             po
-            (P.ProjectorInput "ignore" root images js [f])
+            (P.ProjectorInput "ignore" root images js mo [f])
         for (join . Map.elems . Projector.projectorOutputModuleExprs $ po') $
           fmap ((T.pack . File.takeBaseName $ f), fc,) .
             fmap projectorHtmlToBlaze . hoistEither . first LoomSiteProjectorInterpretError .


### PR DESCRIPTION
Taking this responsibility away from Machinator.

While we want to keep using Machinator's syntax, putting Projector in charge of codegen makes it way easier to write complicated backends. I hit this wall almost immediately when writing the Pux backend.

WIP pending manual compatibility testing